### PR TITLE
Small documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Demo.findOneAndUpdate({ demoField: 'someValue' }, { password: newPwd },
   function(err) { 
     ... 
   });
-  
+
 Demo.findOneAndUpdate({ demoField: 'someValue' }, ( $set: { password: newPwd }},  
   function(err) { 
     ... 
@@ -163,7 +163,7 @@ Demo.findOneAndUpdate({ demoField: 'someValue' }, ( $set: { password: newPwd }},
 
 ## Upsert Query ## 
 
-When [upserting](http://mongoosejs.com/docs/api.html#findoneandupdate_findOneAndUpdate) (find one and update, but if not found create a new document with both the search conditions and update params set) you must use the `$set` operator for the field to be encrypted on the newly created document. 
+When [upserting](http://mongoosejs.com/docs/api.html#findoneandupdate_findOneAndUpdate) you must use the `$set` operator for the field to be encrypted on the newly created document when no existing document is found.
 
 ```javascript
 Demo.findOneAndUpdate({ demoField: 'someValue' }, ( $set: { password: newPwd }}, { upsert: true },

--- a/README.md
+++ b/README.md
@@ -154,8 +154,19 @@ Demo.findOneAndUpdate({ demoField: 'someValue' }, { password: newPwd },
   function(err) { 
     ... 
   });
-
+  
 Demo.findOneAndUpdate({ demoField: 'someValue' }, ( $set: { password: newPwd }},  
+  function(err) { 
+    ... 
+  });
+```
+
+## Upsert Query ## 
+
+When [upserting](http://mongoosejs.com/docs/api.html#findoneandupdate_findOneAndUpdate) (find one and update, but if not found create a new document with both the search conditions and update params set) you must use the `$set` operator for the field to be encrypted on the newly created document. 
+
+```javascript
+Demo.findOneAndUpdate({ demoField: 'someValue' }, ( $set: { password: newPwd }}, { upsert: true },
   function(err) { 
     ... 
   });


### PR DESCRIPTION
I came across a bug in my implementation.
Upserting an existing document correctly hashes the field, but when the upsert creates a new document it saves the field in cleartext. To fix this, I simply needed to use the `$set` operator for my update.

Added this to the documentation to help anyone who runs into the same problem.